### PR TITLE
Correct CSV name in grab_ihme.R

### DIFF
--- a/R/grab_ihme.R
+++ b/R/grab_ihme.R
@@ -10,7 +10,7 @@ grab_ihme <- function(State = state_name){
       download.file(url,temp)
       unzip(zipfile = temp, exdir = temp2)
       folder <- list.files(temp2)
-      IHME <- fread(file.path(temp2, paste0(folder,"/Hospitalization_all_locs.csv") ))
+      IHME <- fread(file.path(temp2, paste0(folder,"/Reference_hospitalization_all_locs.csv") ))
       unlink(c(temp, temp2))
       msg <- paste0("File was updated; new projections for ",folder,". Current files:")
       


### PR DESCRIPTION
Changes name of CSV in grab_ihme.R from Hospitalization_all_locs.csv to Reference_hospitalization_all_locs.csv.

Tested this change with 2 states (California and Iowa), worked correctly after change.

Fixes #11 and #16 