### PR TITLE
Fix missing data

### DIFF
--- a/R/grab_can_county_observed_intervention.R
+++ b/R/grab_can_county_observed_intervention.R
@@ -1,13 +1,13 @@
 grab_can_county_observed_intervention <- function(State = state_name){
-  
+
   list_of_fips_char = make_fips_list()
-  
+
   co <- counties[,.(county, fips)]
-  
-  can.ca.co  <- rbindlist(lapply(list_of_fips_char, function(x) loop_can_cnty_observed(x))) %>% 
+
+  can.ca.co  <- rbindlist(lapply(list_of_fips_char, function(x) loop_can_cnty_observed(x)), fill = TRUE) %>%
     mutate(date = as.Date(date)) %>% merge(co)
-   
-    
+
+
   return(can.ca.co)
-  
+
 }

--- a/R/grab_mobs.R
+++ b/R/grab_mobs.R
@@ -1,29 +1,29 @@
 
 grab_mobs <- function(State = state_name){
-  
+
   State <- ifelse(State %in% c("New York","Washington"), paste0(State, " State"), State)
-  
+
   url <- paste0("https://data-tracking-api-dot-mobs-2019-ncov-web.appspot.com/data?state=",State,"&frequency=daily")
-  
-  
+
+
     tryCatch({
-      mobs <- jsonlite::fromJSON(url)
+      mobs <- jsonlite::fromJSON(URLencode(url))
       mobs <- unique(mobs)
       msg <- paste0("Successfully download data from MOBS for ", State, " on ", Sys.Date())
       print(msg)
       return(mobs)
-      
-      }, error=function(e){ 
-        
+
+      }, error=function(e){
+
         mobs <- jsonlite::fromJSON(paste0("saved_old_versions/mobs_",State,"_data.json"))
         mobs <- unique(mobs)
         msg <- paste0("Problem with MOBS link to file update. Grabbing old copy (June 6, 2020).")
-     
+
      print(msg)
      return(mobs)
       })
-    
-  
+
+
 
 }
 

--- a/R/loop_can_cnty_observed.R
+++ b/R/loop_can_cnty_observed.R
@@ -1,13 +1,15 @@
 loop_can_cnty_observed <- function(fips_code) {
-  
+
   url <- paste0("https://data.covidactnow.org/latest/us/counties/",fips_code,".OBSERVED_INTERVENTION.timeseries.json")
   Sys.sleep(2)
   valid <- as.character(url_file_exists(url)[1])
   print(paste0(fips_code,": ",valid))
   if(valid){
-    cnty <- jsonlite::fromJSON(url)$timeseries %>% as.data.frame() %>% mutate(date = as.Date(date))
+    cnty <- jsonlite::fromJSON(url)$timeseries %>% as.data.frame()
+    if ("date" %in% names(cnty))
+      cnty <- cnty %>% mutate(date = as.Date(date))
     cnty <- mutate(cnty, fips_char = fips_code, fips = as.numeric(fips_code))
     return(cnty)
   }
-  
+
 }


### PR DESCRIPTION
Addresses a handful of situations that affected NC:

- spaces in state name needs to be URL encoded
- missing data for some counties creates problems when the `date` column is missing / `rbindlist` has non-uniform data frames